### PR TITLE
feat: [FFBV-144] 로그인 상태 비밀번호 재설정 UI

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -69,15 +69,36 @@ export const requestPasswordReset = async (body) => {
   }
 };
 
-export const resetPassword = async (token, body) => {
+export const resetPasswordWithoutLogin = async (token, body) => {
   try {
     const response = await api.post(`/password/reset?token=${token}`, body);
     return response;
   } catch (error) {
-    console.error('Reset Password API Error:', error);
+    console.error('Reset Password Without Login API Error:', error);
     throw error;
   }
 };
+
+export const resetPasswordWithLogin = async (body) => {
+  try {
+    const response = await api.patch('/password/reset', body);
+    return response;
+  } catch (error) {
+    console.error('Reset Password With Login API Error:', error);
+    throw error;
+  }
+};
+
+export const reverifyPassword = async (body) => {
+  try {
+    const response = await api.post('/password/reverify', body);
+    return response;
+  } catch (error) {
+    console.error('Reverify Password API Error:', error);
+    throw error;
+  }
+};
+
 
 export const viewProfile = async () => {
   try {

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -8,7 +8,7 @@ import { RouterLink, useRoute, useRouter } from 'vue-router';
 import { ref, computed, onUnmounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/authStore';
 import { extendLogin, logout } from '@/api/user';
-import { clearAccessToken, clearUsername } from '@/utils/authUtil';
+import { clearAccessToken, clearUsername, isReverifiedToken, getAccessToken } from '@/utils/authUtil';
 import SearchModal from '../common/SearchModal.vue';
 import ExtendLoginModal from '../user/auth/ExtendLoginModal.vue';
 import UserModal from '../user/mypage/UserModal.vue';
@@ -122,7 +122,8 @@ watch(
       seconds > 0 &&
       seconds <= WARNING_THRESHOLD_SECONDS &&
       !isExtendLoginModalOpen.value &&
-      !hasDeclinedExtendModal.value
+      !hasDeclinedExtendModal.value &&
+      !isReverifiedToken(getAccessToken())
     )
       isExtendLoginModalOpen.value = true;
     if (seconds < 0) handleLogout();
@@ -180,7 +181,9 @@ onUnmounted(() => {
       <!-- 헤더 - 유저 영역 -->
       <div class="flex gap-x-6 justify-end">
         <template v-if="authStore.isLoggedIn">
-          <span class="text-sm text-gray-500">
+          <span
+            class="text-sm text-gray-500"
+          >
             남은 시간: {{ remainingMinutes }}분 {{ remainingSeconds }}초
           </span>
 

--- a/src/components/user/mypage/ResetPasswordModal.vue
+++ b/src/components/user/mypage/ResetPasswordModal.vue
@@ -1,0 +1,226 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { reverifyPassword, resetPasswordWithLogin, logout } from '@/api/user';
+import { setAccessToken } from '@/utils/authUtil';
+import BaseButton from '@/components/common/BaseButton.vue';
+import EyeClose from '@/components/icons/EyeClose.vue';
+import EyeOpen from '@/components/icons/EyeOpen.vue';
+
+const router = useRouter();
+
+const regex = {
+  password: /^[a-zA-Z\d!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]{8,}$/,
+};
+
+const props = defineProps({
+  isOpen: Boolean,
+  onClose: Function
+});
+
+const errors = ref({});
+const showOldPassword = ref(false);
+const showNewPassword = ref(false);
+const showConfirmPassword = ref(false);
+
+const oldPassword = ref('');
+const newPassword = ref('');
+const confirmPassword = ref('');
+
+const result = ref({
+  message: '',
+  success: false
+});
+
+const canSubmit = computed(() => {
+  return oldPassword.value !== '' && newPassword.value !== '' && confirmPassword.value !== '';
+});
+
+function validatePasswords() {
+  if (!oldPassword.value)
+    errors.value.oldPassword = '비밀번호를 입력해주세요';
+  else
+    delete errors.value.oldPassword;
+
+  if (!newPassword.value)
+    errors.value.newPassword = '비밀번호를 입력해주세요';
+  else if (!regex.password.test(newPassword.value))
+    errors.value.newPassword = '비밀번호는 8자 이상이어야 합니다 (영문자, 숫자, 특수문자 사용 가능)';
+  else
+    delete errors.value.newPassword;
+
+  if (newPassword.value && !confirmPassword.value)
+    errors.value.confirmPassword = '비밀번호를 다시 입력해주세요';
+  else if (newPassword.value !== confirmPassword.value)
+    errors.value.confirmPassword = '비밀번호가 일치하지 않습니다';
+  else
+    delete errors.value.confirmPassword;
+}
+
+function handleClose() {
+  oldPassword.value = '';
+  newPassword.value = '';
+  confirmPassword.value = '';
+  errors.value = {};
+  result.value = { message: '', success: false };
+  showOldPassword.value = false;
+  showNewPassword.value = false;
+  showConfirmPassword.value = false;
+  props.onClose();
+}
+
+async function handleResetPassword() {
+  console.log('===== 로그인 상태 비밀번호 재설정 핸들링 =====');
+
+  validatePasswords();
+
+  let response;
+
+  if (canSubmit.value) {
+    try {
+      console.log("===== reverifyPassword API 호출 =====");
+      response = await reverifyPassword({ confirmPassword: oldPassword.value });
+
+      setAccessToken(response.data.reverifyToken);
+
+      console.log("===== resetPasswordWithLogin API 호출 =====");
+      await resetPasswordWithLogin({ newPassword: newPassword.value, confirmPassword: confirmPassword.value })
+
+      result.value = {
+        message: '비밀번호 재설정이 완료되었습니다. 다시 로그인 해주세요.',
+        success: true
+      };
+
+      await logout();
+
+      setTimeout(() => {
+        router.push('/login');
+      }, 1500);
+
+    } catch (error) {
+      result.value = {
+        message: '오류가 발생했습니다.',
+        success: false
+      };
+    }
+  }
+}
+
+function inputStyleClass(error) {
+  return [
+    'w-full px-3 py-3 my-1 border rounded-md outline-none transition-colors',
+    error ? 'border-red-500 bg-red-100 placeholder-red-500' : 'border-gray-300 focus:border-blue-500',
+  ];
+}
+
+</script>
+
+<template>
+  <dialog v-if="isOpen" class="modal" open>
+    <div class="modal-box max-w-sm">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" @click="handleClose">✕</button>
+      <h3 class="text-lg font-bold mb-6">비밀번호 재설정</h3>
+
+      <!-- 비밀번호 재설정 폼 -->
+      <form @submit.prevent novalidate>
+        <!-- 기존 비밀번호 -->
+        <div class="mb-3 relative">
+          <div class="relative">
+            <input
+              :type="showOldPassword ? 'text' : 'password'"
+              v-model="oldPassword"
+              @blur="validatePasswords()"
+              :class="inputStyleClass(errors.password)"
+              placeholder="기존 비밀번호"
+              :disabled="result.success"
+            />
+
+            <button
+              type="button"
+              tabindex="-1"
+              @click="showOldPassword = !showOldPassword"
+              class="absolute top-1/2 right-3 -translate-y-1/2 flex items-center justify-center"
+            >
+              <EyeOpen v-if="showOldPassword" class="w-4 h-4"></EyeOpen>
+              <EyeClose v-if="!showOldPassword" class="w-4 h-4"></EyeClose>
+            </button>
+          </div>
+
+          <small v-if="errors.password" class="text-red-500 mt-1 block">{{ errors.password }}</small>
+        </div>
+
+        <!-- 새 비밀번호 -->
+        <div class="mb-3 relative">
+          <div class="relative">
+            <input
+              :type="showNewPassword ? 'text' : 'password'"
+              v-model="newPassword"
+              @blur="validatePasswords()"
+              :class="inputStyleClass(errors.password)"
+              placeholder="새 비밀번호 (8자 이상, 영문/숫자/특수문자)"
+              :disabled="result.success"
+            />
+
+            <button
+              type="button"
+              tabindex="-1"
+              @click="showNewPassword = !showNewPassword"
+              class="absolute top-1/2 right-3 -translate-y-1/2 flex items-center justify-center"
+            >
+              <EyeOpen v-if="showNewPassword" class="w-4 h-4"></EyeOpen>
+              <EyeClose v-if="!showNewPassword" class="w-4 h-4"></EyeClose>
+            </button>
+          </div>
+
+          <small v-if="errors.password" class="text-red-500 mt-1 block">{{ errors.password }}</small>
+        </div>
+
+        <!-- 비밀번호 재입력 -->
+        <div class="mb-3 relative">
+          <div class="relative">
+            <input
+              :type="showConfirmPassword ? 'text' : 'password'"
+              v-model="confirmPassword"
+              @blur="validatePasswords()"
+              :class="inputStyleClass(errors.confirmPassword)"
+              placeholder="비밀번호 재입력"
+              :disabled="result.success"
+            />
+
+            <button
+              type="button"
+              tabindex="-1"
+              @click="showConfirmPassword = !showConfirmPassword"
+              class="absolute top-1/2 right-3 -translate-y-1/2 flex items-center justify-center"
+            >
+              <EyeOpen v-if="showConfirmPassword" class="w-4 h-4"></EyeOpen>
+              <EyeClose v-if="!showConfirmPassword" class="w-4 h-4"></EyeClose>
+            </button>
+
+          </div>
+          <small v-if="errors.confirmPassword" class="text-red-500 mt-1 block">{{ errors.confirmPassword }}</small>
+        </div>
+
+        <!-- 변경하기 버튼 -->
+        <BaseButton
+          size="lg"
+          variant="filled"
+          :disabled="!canSubmit || result.success"
+          label="비밀번호 변경"
+          @click="handleResetPassword"
+          class="mt-6"
+        >
+        </BaseButton>
+
+        <!-- 결과 메시지 -->
+        <small
+          v-if="result.message"
+          :class="result.success ? 'text-green-500' : 'text-red-500'"
+          class="mt-2 block pt-2"
+        >
+          {{ result.message }}
+        </small>
+      </form>
+    </div>
+  </dialog>
+</template>

--- a/src/components/user/mypage/ResetPasswordModal.vue
+++ b/src/components/user/mypage/ResetPasswordModal.vue
@@ -130,7 +130,7 @@ function inputStyleClass(error) {
               :type="showOldPassword ? 'text' : 'password'"
               v-model="oldPassword"
               @blur="validatePasswords()"
-              :class="inputStyleClass(errors.password)"
+              :class="inputStyleClass(errors.oldPassword)"
               placeholder="기존 비밀번호"
               :disabled="result.success"
             />
@@ -146,7 +146,7 @@ function inputStyleClass(error) {
             </button>
           </div>
 
-          <small v-if="errors.password" class="text-red-500 mt-1 block">{{ errors.password }}</small>
+          <small v-if="errors.oldPassword" class="text-red-500 mt-1 block">{{ errors.oldPassword }}</small>
         </div>
 
         <!-- 새 비밀번호 -->
@@ -156,7 +156,7 @@ function inputStyleClass(error) {
               :type="showNewPassword ? 'text' : 'password'"
               v-model="newPassword"
               @blur="validatePasswords()"
-              :class="inputStyleClass(errors.password)"
+              :class="inputStyleClass(errors.newPassword)"
               placeholder="새 비밀번호 (8자 이상, 영문/숫자/특수문자)"
               :disabled="result.success"
             />
@@ -172,7 +172,7 @@ function inputStyleClass(error) {
             </button>
           </div>
 
-          <small v-if="errors.password" class="text-red-500 mt-1 block">{{ errors.password }}</small>
+          <small v-if="errors.newPassword" class="text-red-500 mt-1 block">{{ errors.newPassword }}</small>
         </div>
 
         <!-- 비밀번호 재입력 -->

--- a/src/pages/user/auth/PasswordResetPage.vue
+++ b/src/pages/user/auth/PasswordResetPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
-import { resetPassword } from '@/api/user';
+import { resetPasswordWithoutLogin } from '@/api/user';
 import { getTokenIfExists } from '@/utils/authUtil';
 import BaseButton from '@/components/common/BaseButton.vue';
 import EyeClose from '@/components/icons/EyeClose.vue';
@@ -53,14 +53,14 @@ function validatePasswords() {
 }
 
 async function handleResetPassword() {
-  console.log('===== 비밀번호 재설정 핸들링 =====');
+  console.log('===== 비로그인 상태 비밀번호 재설정 핸들링 =====');
 
   validatePasswords();
 
   if (canSubmit.value) {
     try {
-      console.log("===== resetPassword API 호출 =====");
-      await resetPassword(token.value, { newPassword: password.value, confirmPassword: confirmPassword.value })
+      console.log("===== resetPasswordWithoutLogin API 호출 =====");
+      await resetPasswordWithoutLogin(token.value, { newPassword: password.value, confirmPassword: confirmPassword.value })
 
       result.value = {
         message: '비밀번호 재설정이 완료되었습니다. 로그인 페이지로 이동합니다.',

--- a/src/pages/user/mypage/MyPage.vue
+++ b/src/pages/user/mypage/MyPage.vue
@@ -3,8 +3,14 @@ import { reactive, ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { viewProfile } from '@/api/user';
 import RetakeSurveyModal from '@/components/user/mypage/RetakeSurveyModal.vue';
+import ResetPasswordModal from '@/components/user/mypage/ResetPasswordModal.vue';
 
 const router = useRouter();
+
+// 비밀번호 재설정 모달 관련 상태
+const isResetPasswordModalOpen = ref(false);
+
+// 재설문 여부 모달 관련 상태
 const isRetakeSurveyModalOpen = ref(false);
 const surveyType = ref('');
 
@@ -34,22 +40,27 @@ const result = ref({
 });
 
 // 버튼 핸들러
-const changePassword = () => console.log('비밀번호 변경');
+const changePassword = () => {
+  isResetPasswordModalOpen.value = true;
+}
+
 const retakeKnowledgeTest = () => {
   surveyType.value = 'knowledge';
   isRetakeSurveyModalOpen.value = true;
 };
+
 const retakeTendencyTest = () => {
   surveyType.value = 'tendency';
   isRetakeSurveyModalOpen.value = true;
 };
+
 const withdrawAccount = () => console.log('탈퇴하기');
 
 onMounted(() => {
  setUserInfo();
 })
 
-function handleRetakeConfirm() {
+function handleRetakeSurveyConfirm() {
   isRetakeSurveyModalOpen.value = false;
   router.push(`/mypage/survey/${surveyType.value}`);
 }
@@ -176,11 +187,16 @@ async function setUserInfo() {
     </div>
   </div>
 
+  <ResetPasswordModal
+    :isOpen="isResetPasswordModalOpen"
+    :onClose="() => (isResetPasswordModalOpen = false)"
+  />
+
   <RetakeSurveyModal
     :type="surveyType"
     :renewDate="renewDate"
     :isOpen="isRetakeSurveyModalOpen"
     :onClose="() => (isRetakeSurveyModalOpen = false)"
-    @confirm="handleRetakeConfirm"
+    @confirm="handleRetakeSurveyConfirm"
   />
 </template>

--- a/src/utils/authUtil.js
+++ b/src/utils/authUtil.js
@@ -57,6 +57,18 @@ export const getEmailFromToken = (token) => {
   }
 }
 
+export const isReverifiedToken = (token) => {
+  if (token === null)
+    return false;
+
+  try {
+    return parseToken(token).passwordReverified === true;
+  } catch (e) {
+    console.error('토큰 형식 오류: ', e);
+    return false;
+  }
+}
+
 export const parseToken = (token) => {
   const payload = token.split('.')[1];
   const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/')); // base64 디코딩


### PR DESCRIPTION
## 📌 요약

- 로그인 상태 비밀번호 재설정 UI 구현

## 📝 상세 내용

- authUtil.js
  - 비밀번호 재설정 진입점 구분하기 위한 함수명 변경
    - 로그인 -> `resetPasswordWithLogin`
    - 비로그인 -> `resetPasswordWithoutLogin`
- MyPage.vue, ResetPasswordModal.vue
  - 마이페이지에서 비밀번호 변경 버튼 클릭 시 모달 띄움
- Header.vue, authUtil.js
  - accessToken(TTL 30분) -> reverifyToken(TTL 5분) 변경 시 로그인 시간 연장 모달 뜨는 문제 해결
  - 모달 띄우기 전 토큰에서 `passwordReverified` 값 확인, true면 띄우지 않음

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?

-
