### PR TITLE
feat: [FFBV-151] 사용자 관리 에러 처리

### DIFF
--- a/src/pages/user/auth/LoginPage.vue
+++ b/src/pages/user/auth/LoginPage.vue
@@ -155,9 +155,9 @@ function inputStyleClass(field) {
 
         <!-- 하단 링크 -->
         <div class="mt-6 text-center text-xs text-gray-500 space-x-3">
-          <a href="/find" class="hover:underline">아이디 / 비밀번호 찾기</a>
+          <RouterLink to="/find" class="hover:underline">아이디 / 비밀번호 찾기</RouterLink>
           <span>|</span>
-          <a href="/signup/request" class="hover:underline">회원가입</a>
+          <RouterLink to="/signup/request" class="hover:underline">회원가입</RouterLink>
         </div>
       </form>
     </div>

--- a/src/pages/user/auth/SignupPage.vue
+++ b/src/pages/user/auth/SignupPage.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { join } from '@/api/user';
-import { getTokenIfExists, getEmailFromToken, setEmail, clearEmail } from '@/utils/authUtil';
+import { getTokenIfExists, getEmailFromToken, setEmail } from '@/utils/authUtil';
 import PrivacyPolicyModal from '@/components/user/auth/PrivacyPolicyModal.vue';
 import BaseButton from '@/components/common/BaseButton.vue';
 import EyeClose from '@/components/icons/EyeClose.vue';
@@ -144,7 +144,6 @@ async function handleJoinSubmit() {
         success: true
       };
 
-      clearEmail();
       router.push({ name: 'signup/survey', params: { type: 'knowledge' } });
 
     } catch (error) {

--- a/src/pages/user/auth/SignupSuccessPage.vue
+++ b/src/pages/user/auth/SignupSuccessPage.vue
@@ -1,5 +1,7 @@
 <script setup>
+import { onMounted } from 'vue';
 import { useRouter } from 'vue-router';
+import { clearEmail } from '@/utils/authUtil';
 import BaseButton from '@/components/common/BaseButton.vue';
 import ProcessDots from '@/components/icons/survey/ProcessDots.vue';
 import Check from '@/components/icons/survey/Check.vue';
@@ -10,6 +12,10 @@ const router = useRouter();
 async function routeToLoginPage() {
   router.push('/login');
 }
+
+onMounted(() => {
+  clearEmail();
+})
 
 </script>
 

--- a/src/pages/user/auth/SignupSuccessPage.vue
+++ b/src/pages/user/auth/SignupSuccessPage.vue
@@ -15,7 +15,7 @@ async function routeToLoginPage() {
 
 onMounted(() => {
   clearEmail();
-})
+});
 
 </script>
 


### PR DESCRIPTION
## 📌 요약

- 세션 스토리지 이메일 삭제 시점 수정
- 로그인 페이지 라우팅 방법 수정

## 📝 상세 내용

- 세션 스토리지 이메일 삭제 시점 수정
  - 회원가입 직후, 설문조사 전에 삭제 코드 삽입했다가 설문조사 api 호출 시 오류 발생
  - 회원가입 로직 전부 완료 후 삭제되도록 수정

- 로그인 페이지 라우팅 방법 수정
  - 아이디/비밀번호 찾기, 회원가입 페이지로 이동 시 `a` 태그 사용
  - 로컬에서는 문제 없지만 github pages에서 중간 경로(`/halggeol-frontend`) 누락으로 오류 발생
  - `RouterLink`로 수정

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?

-
